### PR TITLE
fix: respect all-namespaces selection when loading pod and overview resources

### DIFF
--- a/src/views/ClusterOverview.vue
+++ b/src/views/ClusterOverview.vue
@@ -450,13 +450,17 @@ const fetchResourceObjects = (resource: V1APIResource): Promise<void> => {
       formatResourceKind(resource.kind).toLowerCase(),
       "--context",
       context.value,
-      "-n",
-      namespace.value,
       "-o",
       "json",
       "--kubeconfig",
       kubeConfig.value,
     ];
+
+    if (namespace.value) {
+      args.push("--namespace", namespace.value);
+    } else {
+      args.push("--all-namespaces");
+    }
 
     try {
       const result = await Kubernetes.kubectl(args);

--- a/src/views/Pods.vue
+++ b/src/views/Pods.vue
@@ -207,7 +207,7 @@ async function getPods(): Promise<V1Pod[]> {
     kubeConfig.value,
   ];
 
-  if (namespace.value !== "all") {
+  if (namespace.value) {
     args.push("--namespace", namespace.value);
   } else {
     args.push("--all-namespaces");
@@ -228,7 +228,7 @@ async function getPodMetrics(): Promise<PodMetric[]> {
     kubeConfig.value,
   ];
 
-  if (namespace.value !== "all") {
+  if (namespace.value) {
     args.push("--namespace", namespace.value);
   } else {
     args.push("--all-namespaces");


### PR DESCRIPTION
### Motivation
- Fix issue where choosing “All namespaces” still resulted in listing resources from the `default` namespace because an empty `--namespace` argument was passed to `kubectl` instead of using `--all-namespaces`.
- Ensure both the Pods view and the Cluster Overview honor the global namespace selection and show resources across all namespaces when appropriate.

### Description
- Updated `src/views/Pods.vue` to build `kubectl` args in `getPods()` and `getPodMetrics()` so that when `namespace.value` is empty it adds `--all-namespaces`, otherwise it adds `--namespace <name>`.
- Updated `src/views/ClusterOverview.vue` in `fetchResourceObjects()` to conditionally append `--namespace <name>` only when `namespace.value` is set and `--all-namespaces` otherwise.
- Changes ensure `kubectl` calls no longer pass an empty `--namespace` value and properly list resources across namespaces when the “All namespaces” selection is active.

### Testing
- Ran type-checking with `npm run ts-check`; the command ran but failed due to many pre-existing TypeScript errors that are unrelated to this namespace logic change. The namespace behavior change itself is a small argument-building fix and does not introduce new type errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af10a32f808325a0ae294e09b67e8b)